### PR TITLE
Tabs Example 1 Missing Active Tab Function

### DIFF
--- a/elements/tabs-examples/example-01.html
+++ b/elements/tabs-examples/example-01.html
@@ -13,6 +13,10 @@
         },
         tabContentActive(tabContent){
             return this.tabSelected == tabContent.id.replace(this.tabId + '-content-', '');
+        },
+        tabButtonActive(tabContent){
+            const tabId = tabContent.id.split('-').slice(-1);
+            return this.tabSelected == tabId;
         }
     }"
     


### PR DESCRIPTION
### Add `tabButtonActive` back to tabs example 1. this is needed for dynamic classnames to work.

**Before:**

- Missing function console error
- Text color isn't darker

<img width="995" alt="image" src="https://github.com/thedevdojo/pines/assets/3633879/80aa8ef8-f659-48d4-ab0c-1a76d1f5d7c4">

**After:**

- No console error
- Text darker

<img width="703" alt="image" src="https://github.com/thedevdojo/pines/assets/3633879/2a769661-a2ea-489c-bce2-f542bba4cfa3">

**Other Notes:**
- Think this was just accidentally a few weeks ago (https://github.com/thedevdojo/pines/commit/5c42b388cacf137a6d7a8b51b1fe44dcb8ab8dba#diff-68b08c735e1fdc2e5e02c8499cca0459d3199cee2e1f5645ed2a1da865bd9d86) 🤷‍♂️ 
- The active class list includes a class to make the tab background darker but the `tabMarker` itself has the darker background so there's some duplication a bit, but leaving as it isn't related to actual functionality