### PR TITLE
use `substring()` instead of deprecated `substr()`

### DIFF
--- a/elements/video-examples/example-01.html
+++ b/elements/video-examples/example-01.html
@@ -107,11 +107,11 @@
             }, this.autoHideControlsDelay);
         },
         formatTime(timeInSeconds) {
-            result = new Date(timeInSeconds * 1000).toISOString().substr(11, 8);
+            result = new Date(timeInSeconds * 1000).toISOString().substring(11, 19);
 
             return {
-                minutes: result.substr(3, 2),
-                seconds: result.substr(6, 2),
+                minutes: result.substring(3, 5),
+                seconds: result.substring(6, 8),
             };
         }
     }"

--- a/elements/video-examples/example-02.html
+++ b/elements/video-examples/example-02.html
@@ -107,11 +107,11 @@
             }, this.autoHideControlsDelay);
         },
         formatTime(timeInSeconds) {
-            result = new Date(timeInSeconds * 1000).toISOString().substr(11, 8);
+            result = new Date(timeInSeconds * 1000).toISOString().substring(11, 19);
 
             return {
-                minutes: result.substr(3, 2),
-                seconds: result.substr(6, 2),
+                minutes: result.substring(3, 5),
+                seconds: result.substring(6, 8),
             };
         }
     }"

--- a/elements/video.html
+++ b/elements/video.html
@@ -107,11 +107,11 @@
             }, this.autoHideControlsDelay);
         },
         formatTime(timeInSeconds) {
-            result = new Date(timeInSeconds * 1000).toISOString().substr(11, 8);
+            result = new Date(timeInSeconds * 1000).toISOString().substring(11, 19);
 
             return {
-                minutes: result.substr(3, 2),
-                seconds: result.substr(6, 2),
+                minutes: result.substring(3, 5),
+                seconds: result.substring(6, 8),
             };
         }
     }"

--- a/getting-started/alpine-plugin.html
+++ b/getting-started/alpine-plugin.html
@@ -49,7 +49,7 @@
             let tooltipText = expression;
             let tooltipArrow = modifiers.includes('noarrow') ? false : true;
             let tooltipPosition = 'top';
-            let tooltipId = 'tooltip-' + Date.now().toString(36) + Math.random().toString(36).substr(2, 5);
+            let tooltipId = 'tooltip-' + Date.now().toString(36) + Math.random().toString(36).substring(2, 7);
             let positions = ['top', 'bottom', 'left', 'right'];
             let elementPosition = getComputedStyle(el).position;
 
@@ -133,7 +133,7 @@ let tooltipArrow = modifiers.includes('noarrow') ? false : true;
 // The default tooltip position will be set to 'top'
 let tooltipPosition = 'top';
 // We need to create a dynamic ID so that way we can reference the tooltip element when we want to add or remove it
-let tooltipId = 'tooltip-' + Date.now().toString(36) + Math.random().toString(36).substr(2, 5);
+let tooltipId = 'tooltip-' + Date.now().toString(36) + Math.random().toString(36).substring(2, 7);
 // These are all the possible positions for the tooltip
 let positions = ['top', 'bottom', 'left', 'right'];
 // We need to check the position of the element that the tooltip is attached to, we'll use this variable in a following step


### PR DESCRIPTION
`substr()` is deprecated, so for better cross platform compatibility, we'll convert these to `substring()`.

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr