### PR TITLE
Use padding instead of margin on checkbox label

### DIFF
--- a/elements/checkbox-examples/example-01.html
+++ b/elements/checkbox-examples/example-01.html
@@ -1,8 +1,9 @@
 <div class="flex items-start mb-6">
     <div class="flex items-center h-5">
-        <input name="remember" id="remember" type="checkbox" class="w-4 h-4 rounded border-neutral-300 bg-neutral-50 focus:ring-3 focus:ring-blue-300" required>
+        <input name="remember" id="remember" type="checkbox"
+            class="w-4 h-4 rounded border-neutral-300 bg-neutral-50 focus:ring-3 focus:ring-blue-300" required>
     </div>
-    <div class="ml-3 text-sm">
+    <div class="pl-3 text-sm">
         <label for="remember" class="text-neutral-900">Remember Me</label>
     </div>
 </div>

--- a/elements/checkbox.html
+++ b/elements/checkbox.html
@@ -1,4 +1,5 @@
 <div class="flex items-center mb-4">
-    <input id="checkbox-id" type="checkbox" class="w-4 h-4 bg-gray-100 border-gray-300 rounded text-neutral-900 focus:ring-neutral-900">
-    <label for="checkbox-id" class="ml-2 text-sm font-medium text-gray-900">Checkbox</label>
+    <input id="checkbox-id" type="checkbox"
+        class="w-4 h-4 bg-gray-100 border-gray-300 rounded text-neutral-900 focus:ring-neutral-900">
+    <label for="checkbox-id" class="pl-2 text-sm font-medium text-gray-900">Checkbox</label>
 </div>


### PR DESCRIPTION
We can use padding so that in the space between the checkbox input element, and the label to the checkbox, there is not a deadspace where interaction is impossible.